### PR TITLE
fix el definition compatibility in client.js

### DIFF
--- a/app/static/client.js
+++ b/app/static/client.js
@@ -1,4 +1,6 @@
-var el = x => document.getElementById(x);
+function el(x) {
+  return document.getElementById(x);
+}
 
 function showPicker() {
   el("file-input").click();


### PR DESCRIPTION
The previous definition (using the `=>` syntax) would occasionally break the definition on certain browsers, notably for me, an older version of chrome.